### PR TITLE
Add unary_error function

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -14,6 +14,7 @@
          add_trailers/2,
          set_trailers/2,
          code_to_status/1,
+         unary_error/3,
          error/2,
          ctx/1,
          ctx/2,
@@ -85,11 +86,11 @@ on_receive_headers(Headers, State=#state{ctx=_Ctx}) ->
     %% proplists:get_value(<<":method">>, Headers) =:= <<"POST">>,
     Metadata = grpcbox_utils:headers_to_metadata(Headers),
     Ctx = case parse_options(<<"grpc-timeout">>, Headers) of
-               infinity ->
-                   grpcbox_metadata:new_incoming_ctx(Metadata);
-               D ->
-                   ctx:with_deadline_after(grpcbox_metadata:new_incoming_ctx(Metadata), D, nanosecond)
-           end,
+              infinity ->
+                  grpcbox_metadata:new_incoming_ctx(Metadata);
+              D ->
+                  ctx:with_deadline_after(grpcbox_metadata:new_incoming_ctx(Metadata), D, nanosecond)
+          end,
 
     FullPath = proplists:get_value(<<":path">>, Headers),
     %% wait to rpc_begin here since we need to know the method
@@ -376,12 +377,17 @@ unary_reply(Message, Ctx) ->
     #state{handler=Pid} = from_ctx(Ctx),
     h2_stream:call(Pid, {unary_reply, Message}).
 
+unary_error(Status, Message, #state{handler=Pid}) ->
+    h2_stream:call(Pid, {grpc_error, {Status, Message}}).
+
 handle_call(ctx, State=#state{ctx=Ctx}) ->
     {ok, Ctx, State};
 handle_call({ctx, Ctx}, State) ->
     {ok, ok, State#state{ctx=Ctx}};
 handle_call({unary_reply, Message}, State) ->
-    {ok, ok, end_stream(send(false, Message, State))}.
+    {ok, ok, end_stream(send(false, Message, State))};
+handle_call({grpc_error, {Status, Message}}, State) ->
+    {ok, ok, end_stream(Status, Message, State)}.
 
 handle_info({add_headers, Headers}, State) ->
     update_headers(Headers, State);


### PR DESCRIPTION
In `grpcbox_stream` there is no way to send a grpc error if the
`grpcbox_stream` isn't the ownign process. This is the case when you
would typically return a success with `grpcbox_stream:unary_reply`.

This change adds the `grpcbox_stream:unary_error` function for this case