### PR TITLE
Correct end stream return

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -417,9 +417,11 @@ handle_call(ctx, State=#state{ctx=Ctx}) ->
 handle_call({ctx, Ctx}, State) ->
     {ok, ok, State#state{ctx=Ctx}};
 handle_call({unary_reply, Message}, State) ->
-    {ok, ok, end_stream(send(false, Message, State))};
+    {ok, State1} = end_stream(send(false, Message, State)),
+    {ok, ok, State1};
 handle_call({grpc_error, {Status, Message}}, State) ->
-    {ok, ok, end_stream(Status, Message, State)}.
+    {ok, State1} = end_stream(Status, Message, State),
+    {ok, ok, State1}.
 
 handle_info({add_headers, Headers}, State) ->
     update_headers(Headers, State);


### PR DESCRIPTION

```erlang
=ERROR REPORT==== 21-Aug-2023::07:07:46.135817 ===
    supervisor: {local,'grpcbox_pool_0.0.0.0_8080'}
    errorContext: child_terminated
    reason: {function_clause,
                [{grpcbox_stream,end_stream,
                     [<<"0">>,<<>>,
                      {ok,{state,<0.31430.35>,
                              {gen_tcp,#Port<0.26873>},
                              undefined,<<>>,
                              {ctx,
                              ...
```